### PR TITLE
Fix DZR_CBC extraction on *BSD like

### DIFF
--- a/dzr
+++ b/dzr
@@ -1,4 +1,17 @@
 #!/bin/sh
+
+GNUGREP="grep"
+case $(uname | tr '[:upper:]' '[:lower:]') in
+  netbsd|openbsd|darwin*)
+    GNUGREP="ggrep"
+    ;;
+  freebsd*)
+    GNUGREP="/usr/local/bin/grep"
+    ;;
+  *)
+    ;;
+esac
+
 # dependencies check, see: https://github.com/yne/dzr/issues/12
 FETCH=${FETCH:-curl -s} # FETCH="wget -q -O -" or FETCH="curl -s -k"
 # handle CGI call, for example moving ./dzr* bin to ~/cgi-bin and running :
@@ -20,8 +33,8 @@ unscramble(){ printf "${8}${16}${7}${15}${6}${14}${5}${13}${4}${12}${3}${11}${2}
 # extraction + warning by charleywright, see: https://github.com/yne/dzr/issues/11
 if [ -z "$DZR_CBC" ]; then
 	echo -e "WARNING:\nDZR_CBC variable is unset\nextracting from web-player..."
-	APP_WEB=$($FETCH -L deezer.com/en/channels/explore | grep -Po "(?<=(script src=\"))https:\/\/[a-z-\.\/]+app-web[a-z0-9\.]+" | xargs $FETCH -L)
-	TMP_CBC=$(echo "$APP_WEB" | grep -Po "%5B(0x31|0x61)(%2C0x[0-9a-f]{2}){7}%5D" |  sed 's/%5[BD]//g;s/%/\\x/g' | xargs -0 printf %b | sed 's/0x/\\x/g;s/,/\n/g' | xargs -0 printf %b)
+	APP_WEB=$($FETCH -L deezer.com/en/channels/explore | ${GNUGREP} -Po "(?<=(script src=\"))https:\/\/[a-z-\.\/]+app-web[a-z0-9\.]+" | xargs $FETCH -L)
+	TMP_CBC=$(echo "$APP_WEB" | ${GNUGREP} -Po "%5B(0x31|0x61)(%2C0x[0-9a-f]{2}){7}%5D" |  sed 's/%5[BD]//g;s/%/\\x/g' | xargs -0 printf %b | sed 's/0x/\\x/g;s/,/\n/g' | xargs -0 printf %b)
 	export DZR_CBC=$(unscramble $TMP_CBC);
 	echo -e "    echo \"export DZR_CBC="$DZR_CBC"\" >> .profile\nto avoid this warning"
 	sleep 2 # give time to read the warning


### PR DESCRIPTION
The grep command for the DZR_CBC extract use gnu extension.

P and o arguments are not POSIX and have a different meaning on BSD system.
You have to install gnugrep and use it directly.
Either by the g prefixed version on OpenBSD, NetBSD and macOs(Darwin) or
the standard PATH for port on FreeBSD.


Tested on FreeBSD